### PR TITLE
[Bugfix] NixOS dev-container database wasn't initialized properly

### DIFF
--- a/nix/dev-container
+++ b/nix/dev-container
@@ -11,5 +11,5 @@ fi
 nixos-container start pepa-dev
 
 if [ $initial ]; then
-    $root/psql < "$root/../db/schema.sql"
+    $root/psql < "$root/../resources/schema.sql"
 fi


### PR DESCRIPTION
Database of nix/dev-container wasn't initialized properly (file not found / wrong filepath) causing "nix/lein run" to throw PostrgreSQL exceptions
