### PR TITLE
Fix: no pdfunite when downloading single file documents

### DIFF
--- a/src/pepa/model.clj
+++ b/src/pepa/model.clj
@@ -472,15 +472,17 @@
                                   (pdf/split-pdf data (map :number pages)))]))
             pages (map #(assoc % :pdf-file (get-in page-files [(:file %) (:number %)])) pages)]
         (let [page-files (map :pdf-file pages)]
-          (try
-            ;; Rotate the pages if necessary
-            (let [page-files (for [page pages]
-                               (let [original (:pdf-file page)]
-                                 (pdf/rotate-pdf-file original (:rotation page))))]
-              (pdf/merge-pages page-files))
-            (finally
-              (doseq [file page-files]
-                (.delete file)))))))
+          (if (<= (count page-files) 1)
+            (first page-files)
+            (try
+              ;; Rotate the pages if necessary
+              (let [page-files (for [page pages]
+                                 (let [original (:pdf-file page)]
+                                   (pdf/rotate-pdf-file original (:rotation page))))]
+                (pdf/merge-pages page-files))
+              (finally
+                (doseq [file page-files]
+                  (.delete file))))))))
     (catch IOException e
       (log/error db e "Couldn't generate PDF")
       ;; Rethrow

--- a/src/pepa/pdf.clj
+++ b/src/pepa/pdf.clj
@@ -174,7 +174,7 @@
         exit-code (.waitFor process)]
     (when-not (zero? exit-code)
       (.delete file)
-      (throw (ex-info "pdfunit didn't terminate correctly"
+      (throw (ex-info "pdfunite didn't terminate correctly"
                       {:exit-code exit-code
                        :args args
                        :pages pages})))


### PR DESCRIPTION
This fixes #6 for me. Wasn't able to try this with multi-page-file pdfs, as I didn't understand how to get those into the system.
