### PR TITLE
Update project.clj for Windows

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -70,7 +70,8 @@
                org.clojure/tools.reader]
   :source-paths ["src/" "src-cljs/"]
   :main pepa.core
-  :plugins [[lein-figwheel "0.5.8"]]
+  :plugins [[lein-figwheel "0.5.8"]
+            [lein-cljsbuild "1.1.4"]]
   :cljsbuild {:builds {:pepa {:source-paths ["src/" "src-cljs/"]
                               :figwheel true
                               :compiler {:main "pepa.core"


### PR DESCRIPTION
In win10, I can't run `lein cljsbulid once` and get a error message.
> 'cljsbuild' is not a task. See 'lein help'.

Here is the [document](https://github.com/emezeske/lein-cljsbuild#basic-configuration)